### PR TITLE
Session authenticator to obtain JWTs

### DIFF
--- a/addon/authenticators/jwt-session-authenticator.js
+++ b/addon/authenticators/jwt-session-authenticator.js
@@ -1,0 +1,17 @@
+import config from 'ember-get-config';
+import JWTAuthenticator from 'drf-ember-frontend/authenticators/jwt-authenticator';
+import { inject } from '@ember/service';
+
+const JWTSessionAuthenticator = JWTAuthenticator.extend({
+  cookies: inject('cookies'),
+  init() {
+    this._super(...arguments);
+    const conf = config['ember-simple-auth-token'] || {};
+    this.serverTokenEndpoint = conf.serverTokenSessionEndpoint || '/api/token-session/';
+    // This authenticator needs to include the CSRF token
+    const csrftoken =  this.get('cookies').read('csrftoken');
+    this.headers['X-CSRFTOKEN'] = csrftoken;
+  },
+});
+
+export default JWTSessionAuthenticator;

--- a/addon/controllers/get-token.js
+++ b/addon/controllers/get-token.js
@@ -23,7 +23,7 @@ export default Controller.extend({
     if(session.get('isAuthenticated')) {
       this.success();
     } else {
-      session.authenticate(authenticator, credentials).then(() => { this.success(); }, () => { this.failure(); });
+      session.authenticate(authenticator, credentials).then(this.success.bind(this), this.failure.bind(this));
     }
   }
 });

--- a/addon/controllers/get-token.js
+++ b/addon/controllers/get-token.js
@@ -1,0 +1,29 @@
+import Controller from '@ember/controller';
+import { inject } from '@ember/service';
+
+export default Controller.extend({
+  session: inject('session'),
+  successRoute: null,
+  failureRoute: null,
+  success() {
+    this.transitionToRoute(this.get('successRoute'));
+  },
+  failure() {
+    this.transitionToRoute(this.get('failureRoute'));
+  },
+  init() {
+    this._super(...arguments);
+    this.getToken();
+  },
+  getToken() {
+    const authenticator = 'authenticator:jwt-session-authenticator'; // Find the authenticator that uses the session
+    const credentials = {};
+    const session = this.get('session');
+
+    if(session.get('isAuthenticated')) {
+      this.success();
+    } else {
+      session.authenticate(authenticator, credentials).then(() => { this.success(); }, () => { this.failure(); });
+    }
+  }
+});

--- a/addon/controllers/login.js
+++ b/addon/controllers/login.js
@@ -1,0 +1,19 @@
+import Controller from '@ember/controller';
+import { inject } from '@ember/service';
+import config from 'ember-get-config';
+
+export default Controller.extend({
+  session: inject('session'),
+  isDevelopmentMode: config['environment']=== 'development',
+  authorizeUrl: config['APP']['AUTHORIZE_URL'],
+  actions: {
+    authenticate() {
+      // Now using JWT
+      const authenticator = 'authenticator:jwt-authenticator'; // Causes JWT authenticator to be used
+      const credentials = this.getProperties('username', 'password');
+      this.get('session').authenticate(authenticator, credentials).catch((reason) => {
+        this.set('errorMessage', reason);
+      });
+    }
+  }
+});

--- a/app/authenticators/jwt-session-authenticator.js
+++ b/app/authenticators/jwt-session-authenticator.js
@@ -1,0 +1,1 @@
+export { default } from 'drf-ember-frontend/authenticators/jwt-session-authenticator';

--- a/app/controllers/get-token.js
+++ b/app/controllers/get-token.js
@@ -1,0 +1,1 @@
+export { default } from 'drf-ember-frontend/controllers/get-token';

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -1,0 +1,1 @@
+export { default } from 'drf-ember-frontend/controllers/login';

--- a/tests/unit/authenticators/jwt-authenticator-test.js
+++ b/tests/unit/authenticators/jwt-authenticator-test.js
@@ -1,7 +1,8 @@
 import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('authenticator:jwt-authenticator', 'Unit | Authenticator | DRF Token Authenticator', {
-  unit: true
+moduleFor('authenticator:jwt-authenticator', 'Unit | Authenticator | JWT Authenticator', {
+  unit: true,
+  needs: ['service:cookies']
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/authenticators/jwt-session-authenticator-test.js
+++ b/tests/unit/authenticators/jwt-session-authenticator-test.js
@@ -1,0 +1,25 @@
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from '@ember/object';
+
+moduleFor('authenticator:jwt-session-authenticator', 'Unit | Authenticator | JWT Session Authenticator', {
+  unit: true,
+  needs: ['service:cookies']
+});
+
+test('it exists', function(assert) {
+  let authenticator = this.subject();
+  assert.ok(authenticator);
+});
+
+test('it adds csrftoken to headers', function(assert) {
+  assert.expect(2);
+  let authenticator = this.subject({
+    cookies: EmberObject.create({
+      read(key) {
+        assert.equal(key, 'csrftoken');
+        return 'csrf-token-123';
+      }
+    })
+  });
+  assert.deepEqual(authenticator.get('headers'), {'X-CSRFTOKEN': 'csrf-token-123'});
+});

--- a/tests/unit/controllers/get-token-test.js
+++ b/tests/unit/controllers/get-token-test.js
@@ -1,0 +1,74 @@
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import { resolve, reject } from 'rsvp';
+
+moduleFor('controller:get-token', 'Unit | Controller | get token', {
+  needs: ['service:session'],
+});
+
+const MockSession = EmberObject.extend({
+  isAuthenticated: false,
+  authenticate() { return resolve(); }
+});
+
+test('it exists', function(assert) {
+  let controller = this.subject({
+    session: MockSession.create(),
+    transitionToRoute() {}
+  });
+  assert.ok(controller);
+});
+
+test('it authenticates with jwt-session-authenticator when not authenticated', function(assert) {
+  assert.expect(1);
+  const session = MockSession.create({
+    authenticate(authenticator) {
+      assert.equal(authenticator, 'authenticator:jwt-session-authenticator');
+      return resolve();
+    },
+  });
+  this.subject({
+    session: session,
+    transitionToRoute() {}
+  });
+});
+
+test('it does not call authenticate() when session is authenticated', function(assert) {
+  assert.expect(1);
+  const session = MockSession.create({
+    isAuthenticated: true,
+    authenticate() { assert.fail(); },
+  });
+  this.subject({
+    session: session,
+    transitionToRoute() { assert.ok(true); }
+  });
+});
+
+test('it transitions to failureRoute when authentication fails', function(assert) {
+  assert.expect(1);
+  const session = MockSession.create({
+    authenticate() { return reject(); }
+  });
+  this.subject({
+    failureRoute: '/failure',
+    session: session,
+    transitionToRoute(destination) {
+      assert.equal(destination, '/failure');
+    }
+  });
+});
+
+test('it transitions to successRoute when authentication succeeds', function(assert) {
+  assert.expect(1);
+  const session = MockSession.create({
+    authenticate() { return resolve(); },
+  });
+  this.subject({
+    successRoute: '/success',
+    session: session,
+    transitionToRoute(destination) {
+      assert.equal(destination, '/success');
+    }
+  });
+});

--- a/tests/unit/controllers/login-test.js
+++ b/tests/unit/controllers/login-test.js
@@ -1,0 +1,38 @@
+import { moduleFor, test } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import { resolve, reject } from 'rsvp';
+import { run } from '@ember/runloop';
+
+moduleFor('controller:login', 'Unit | Controller | login', {
+  needs: ['service:session']
+});
+
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});
+
+test('it calls authenticator.authenticate()', function(assert) {
+  assert.expect(1);
+  let controller = this.subject({
+      session: EmberObject.create({
+        authenticate() {
+          assert.ok(true);
+          return resolve();
+        }
+      })
+    });
+    controller.send('authenticate')
+});
+
+test('it sets errorMessage when authenticator.authenticate() fails', function(assert) {
+  let controller = this.subject({
+    session: EmberObject.create({
+      authenticate() { return reject('failed to authenticate'); }
+    })
+  });
+  run(() => {
+    controller.send('authenticate');
+  });
+  assert.equal(controller.get('errorMessage'), 'failed to authenticate');
+});


### PR DESCRIPTION
This pull request includes an authenticator and a pair of controllers to support getting a JWT from a DRF server using session authentication.

- The `login` controller includes logic for both development-side login (enter username/password into a form field and get a JWT) and for session-authenticated login (e.g. OAuth or Django Session). The consuming application is expected to provide a `.hbs` template that connects to the login actions. 
- The `get-token` controller, on init, uses the `jwt-session-authenticator` to get a token from the Django server. This will only succeed if the browser has an authenticated django session (e.g. from OAuth) and the django server is on the same domain as the UI (production configurations)
- The `jwt-session-authenticator` is a slight customization of the JWT authenticator from ember-simple-auth-token. It sets the token url to the [new endpoint gcb-web-auth](https://github.com/Duke-GCB/gcb-web-auth/blob/f9def347476ed2f0c003bf815834d0659a904004/gcb_web_auth/jwt_views.py#L13) and updates the request headers to include the CSRF token as django expects it.

For https://github.com/Duke-GCB/bespin-ui/issues/48